### PR TITLE
Feature/aldo makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ run: ## Carga entorno y mostrar variables
 	$(SHELL) -c "source src/cargar_env.sh && src/mostrar_env.sh"
 
 prepare: ## Preparar variables de entorno e instalar dependencias
-	cp docs/.env.example .env
+	@cp docs/.env.example .env
+	@chmod +x src/*.sh
 	@echo "Instalando dependencias..."
 	@if ! command -v bats >/dev/null 2>&1; then \
 		echo "Instalando bats-core localmente..."; \
@@ -39,9 +40,9 @@ tools: ## Verificar dependencias
 
 check: ## Ejecuta scripts de verificación manual (HTTP/DNS)
 	@echo "Ejecutando check_http.sh..."
-	@./scripts/check_http.sh
+	@./src/check_http.sh
 	@echo "Ejecutando check_dns.sh..."
-	@./scripts/check_dns.sh
+	@./src/check_dns.sh
 
 clean: ## Limpiar archivos generados
-	rm -rf $(OUT_DIR) $(DIST_DIR)
+	@rm -rf $(OUT_DIR) $(DIST_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.PHONY: all check clean help run test tools
+
+.DEFAULT_GOAL := help
+SHELL := /bin/bash
+OUT_DIR := out
+DIST_DIR := dist
+TEST_DIR := tests
+
+all: prepare tools test run
+
+help: ## Mostrar los targets disponibles
+	@echo "Make targets:"
+	@grep -E '^[a-zA-Z0-9_\-]+:.*?##' $(MAKEFILE_LIST) | \
+		awk 'BEGIN{FS=":.*?##"}{printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+run: ## Carga entorno y mostrar variables
+	$(SHELL) -c "source src/cargar_env.sh && src/mostrar_env.sh"
+
+prepare: ## Preparar variables de entorno e instalar dependencias
+	cp docs/.env.example .env
+	@echo "Instalando dependencias..."
+	@if ! command -v bats >/dev/null 2>&1; then \
+		echo "Instalando bats-core localmente..."; \
+		git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core; \
+		mkdir -p $(HOME)/.local/bin; \
+		/tmp/bats-core/install.sh $(HOME)/.local; \
+		echo "Añade esto a tu PATH si aún no está:"; \
+		echo "  export PATH=\$$HOME/.local/bin:\$$PATH"; \
+	fi
+
+test: ## Ejecuta pruebas con BATS
+	@echo "Ejecutando pruebas con BATS"
+	@bats $(TEST_DIR)/*.bats
+
+tools: ## Verificar dependencias
+	@command -v dig >/dev/null 2>&1 || { echo "Falta dig"; exit 1; }
+	@command -v curl >/dev/null 2>&1 || { echo "Falta curl"; exit 1; }
+	@command -v bats >/dev/null 2>&1 || { echo "Falta bats"; exit 1; }
+
+check: ## Ejecuta scripts de verificación manual (HTTP/DNS)
+	@echo "Ejecutando check_http.sh..."
+	@./scripts/check_http.sh
+	@echo "Ejecutando check_dns.sh..."
+	@./scripts/check_dns.sh
+
+clean: ## Limpiar archivos generados
+	rm -rf $(OUT_DIR) $(DIST_DIR)

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -77,3 +77,26 @@ Ambos scripts guardan sus resultados en el directorio `out/` con nomenclatura es
 - DNS: `dns_{tipo}_{dominio}_{timestamp}.txt`
 
 Esto permite mantener un historial de validaciones y facilita el debugging de problemas intermitentes.
+
+### Makefile inicial y pruebas BATS
+
+#### Prueba automatizada con BATS
+
+Se implementó una prueba en BATS (.bats) para validar que el endpoint de configuración definido en .env está disponible.
+
+Usamos la variable CONFIG_URL en .env que apunta al endpoint de configuración (ej. https://example.com/config.json).
+Se usa con `curl` con los flags -s -o /dev/null -w "%{http_code}" para obtener únicamente el código de estado HTTP de la respuesta. La prueba pasa solo si el endpoint está disponible y responde 200 OK.
+
+#### Automatizar flujo de trabajo con Makefile
+
+Se implementó un Makefile en la raíz del proyecto para estandarizar tareas comunes:
+
+- help: target por defecto que lista todos los comandos disponibles
+- prepare: crea .env desde la plantilla e instala bats-core localmente
+- tools: valida dependencias (curl, dig, bats)
+- test: corre pruebas unitarias con bats
+- check: ejecuta los scripts de validación HTTP y DNS
+- run: carga y muestra variables de entorno
+- clean: limpia directorios out/ y dist/
+
+Tener este Makefile asegura reproducibilidad, compatibilidad en Linux/WSL y simplifica el flujo de trabajo del equipo.

--- a/tests/test_http.bats
+++ b/tests/test_http.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+setup() {
+  # Cargar variables de entorno desde .env si existe
+  if [ -f ".env" ]; then
+    source ".env"
+  else
+    skip "No se encontró .env"
+  fi
+}
+
+@test "La URL de configuración responde con 200" {
+  run curl -s -o /dev/null -w "%{http_code}" "$CONFIG_URL"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 200 ]
+}


### PR DESCRIPTION
## ¿Qué se hizo?

- Se agregó un Makefile en la raíz del proyecto con los targets check, clean, help, run, test y tools.
- Se creó la primera prueba automatizada con BATS en tests/ para validar que la variable CONFIG_URL responde con código 200 OK.
- Se actualizó la documentación en docs/bitacora-sprint-1.md explicando el uso del Makefile y la prueba BATS.

 ## ¿Por qué?
 
 - Centralizar la ejecución de tareas comunes en un Makefile, facilitando el onboarding de nuevos colaboradores.
 - Automatizar validaciones de endpoints mediante pruebas reproducibles con BATS.
 - Reducir errores manuales y asegurar consistencia entre entornos de desarrollo.
 
## ¿Cómo?

- El target prepare crea .env a partir de docs/.env.example e instala bats-core localmente si no está disponible.
- El target test usa BATS para correr los archivos .bats dentro del directorio tests/.
- La prueba CONFIG_URL responde con 200 utiliza curl para hacer un request y verifica que la respuesta sea 200 OK.
- Los códigos de salida de las pruebas permiten integración futura en pipelines CI/CD.

Close #5 