### PR TITLE
Feature/aldo administracion simulada

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,11 @@ check: ## Ejecuta scripts de verificación manual (HTTP/DNS)
 	@echo "Ejecutando check_dns.sh..."
 	@./src/check_dns.sh
 
+service-start: ## Iniciar servicio simulado
+	@./src/run_service.sh &
+
+service-stop: ## Parar servicio simulado con SIGTERM
+	@kill -TERM $$(cat out/service.pid)
+
 clean: ## Limpiar archivos generados
 	@rm -rf $(OUT_DIR) $(DIST_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all check clean help run test tools
+.PHONY: all check clean help run test tools service-start service-stop
 
 .DEFAULT_GOAL := help
 SHELL := /bin/bash

--- a/docs/bitacora-sprint-2.md
+++ b/docs/bitacora-sprint-2.md
@@ -47,3 +47,21 @@
 - **Código 1**: Error en resolución DNS/HTTP o validación  
 - **Código 130**: Interrupción por usuario (Ctrl+C)
 - **Documentación completa**: Creado `docs/contrato-salidas.md` con ejemplos.
+
+## Ejecución y administración del servicio simulado (run_service.sh)
+
+### Inicio del servicio con Make
+
+Al ejecutar el target service-start, el script run_service.sh se pone en ejecución en segundo plano. Durante este proceso, se crea un archivo de PID en la carpeta out/ que permite identificar el proceso en ejecución, y también se abre un archivo de log (service.log) donde se registran las actividades periódicas del servicio.
+
+### Registro de actividad en out/service.log
+
+El archivo de log registra el inicio, las validaciones periódicas y la recepción de señales del servicio simulado. Este registro sirve como evidencia del comportamiento de este servicio y facilita su observación y depuración.
+
+### Detención y limpieza del servicio
+
+Al ejecutar el target service-stop, se envía una señal SIGTERM al proceso, el cual maneja la señal de manera controlada. Registra la orden de detenerse y elimina el archivo PID. Solo queda el log como evidencia de la ejecución.
+
+### Simulación de un servicio real con systemd
+
+En un entorno real, este mismo script podría instalarse como un servicio de systemd con el nombre pipeline.service. Los comandos de administración se realizarían mediante systemctl (por ejemplo, iniciar, detener o consultar el estado del servicio). Los registros ya no se almacenarían en un archivo local, sino que estarían disponibles en el sistema mediante journalctl, con las ventajas de integración, timestamps oficiales y rotación automática de logs.

--- a/src/run_service.sh
+++ b/src/run_service.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+LOGFILE="out/service.log"
+PIDFILE="out/service.pid"
+
+# Simular permisos restrictivos (umask)
+umask 027
+
+# Función para terminar limpio
+cleanup() {
+    echo "$(date +"%F %T") - Recibí SIGTERM, cerrando servicio..." >> "$LOGFILE"
+    rm -f "$PIDFILE"
+    exit 0
+}
+
+trap cleanup SIGTERM
+
+mkdir -p out
+echo $$ > "$PIDFILE"
+echo "$(date +"%F %T") - Servicio iniciado con PID $$" >> "$LOGFILE"
+
+# Simulación: bucle infinito validando algo cada 5s
+while true; do
+    echo "$(date +"%F %T") - Validando targets (ejemplo: google.com)" >> "$LOGFILE"
+    sleep 5
+done

--- a/src/run_service.sh
+++ b/src/run_service.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 LOGFILE="out/service.log"
@@ -20,7 +20,7 @@ mkdir -p out
 echo $$ > "$PIDFILE"
 echo "$(date +"%F %T") - Servicio iniciado con PID $$" >> "$LOGFILE"
 
-# Simulación: bucle infinito validando algo cada 5s
+# Simulación: bucle infinito validando algo cada 2s
 while true; do
     echo "$(date +"%F %T") - Validando targets (ejemplo: google.com)" >> "$LOGFILE"
     sleep 5

--- a/systemd/pipeline.service
+++ b/systemd/pipeline.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Servicio de validación pipeline http/dns
+
+[Service]
+ExecStart=/bin/bash ../src/run_service.sh
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## ¿Qué?

- Se creó el script `src/run_service.sh` para simular un servicio en segundo plano.
- Se añadieron targets `service-start` y `service-stop` al `Makefile`.
- Se implementó manejo de señales (`SIGTERM`) y limpieza automática de recursos.
- Se documentó el comportamiento del servicio en `docs/bitacora-sprint-2.md`.

## ¿Por qué?

- Simular el ciclo de vida de un servicio sin necesidad de usar `nginx` ni systemd real.
- Dejar registro reproducible en logs y archivos de PID.

## ¿Cómo?

- El servicio escribe actividad en `out/service.log` y crea un archivo `out/service.pid`.
- Al recibir `SIGTERM`, el servicio cierra de forma controlada y elimina el PID.
- Los targets de Make orquestan la ejecución y detención del servicio.
- Se incluyó una explicación de cómo sería la integración real con `systemd` y `journalctl`.

Closes #7 